### PR TITLE
use hashlib instead for scrypt

### DIFF
--- a/python/awswaf/verify.py
+++ b/python/awswaf/verify.py
@@ -1,10 +1,17 @@
-import hashlib
 import binascii
-from typing import Union, Callable, Any
-import pyscrypt
+import hashlib
 import itertools
+from typing import (
+    Any,
+    Callable,
+    Optional
+)
+
 
 def _check(digest: bytes, difficulty: int) -> bool:
+    """
+    Return True if digest has at least difficulty leading zero bits.
+    """
     full, rem = divmod(difficulty, 8)
     if digest[:full] != b"\x00" * full:
         return False
@@ -12,37 +19,48 @@ def _check(digest: bytes, difficulty: int) -> bool:
         return False
     return True
 
-def hash_pow(challenge_input, checksum, difficulty):
-    combined_bytes = (challenge_input + checksum).encode('utf-8')
-    for nonce in itertools.count(0):
-        data = combined_bytes + str(nonce).encode()
-        digest = hashlib.sha256(data).digest()
+
+def hash_pow(challenge: str, salt: str, difficulty: int) -> Optional[str]:
+    """
+    Find a nonce so that sha256(challenge + salt + nonce) meets difficulty.
+    """
+    prefix = (challenge + salt).encode()
+    for nonce in itertools.count():
+        digest = hashlib.sha256(prefix + str(nonce).encode()).digest()
         if _check(digest, difficulty):
             return str(nonce)
     return None
 
 
-def scrypt_func(input_str, salt_str, memory_cost):
-    return binascii.hexlify(
-        pyscrypt.hash(
-            password=input_str.encode(),
-            salt=salt_str.encode(),
-            N=memory_cost, r=8, p=1, dkLen=16
-        )
-    ).decode()
+def scrypt_func(input_str: str, salt: str, n: int = 128, r: int = 8, p: int = 1, dklen: int = 16) -> str:
+    """
+    Compute scrypt hash and return hex-encoded string.
+    """
+    raw = hashlib.scrypt(password=input_str.encode(), salt=salt.encode(), n=n, r=r, p=p, dklen=dklen)
+    return binascii.hexlify(raw).decode()
 
-def compute_scrypt_nonce(challenge_input, checksum, difficulty):
-    combined = challenge_input + checksum
-    salt = checksum
-    memory = 128
-    for nonce in itertools.count(0):
-        result = scrypt_func(f"{combined}{nonce}", salt, memory)
-        if _check(binascii.unhexlify(result), difficulty):
+
+def compute_scrypt_nonce(
+    challenge: str,
+    salt: str,
+    difficulty: int,
+    n: int = 128,
+    r: int = 8,
+    p: int = 1,
+    dklen: int = 16
+) -> Optional[str]:
+    """
+    Find a nonce so that scrypt(challenge + salt + nonce) meets difficulty.
+    """
+    prefix = challenge + salt
+    for nonce in itertools.count():
+        digest = hashlib.scrypt(password=f"{prefix}{nonce}".encode(), salt=salt.encode(), n=n, r=r, p=p, dklen=dklen)
+        if _check(digest, difficulty):
             return str(nonce)
     return None
 
 
-CHALLENGE_TYPES: dict[str, Union[Callable[[Any, Any, Any], str], str]] = {
+CHALLENGE_TYPES: dict[str, Callable[..., Any]] = {
     'h72f957df656e80ba55f5d8ce2e8c7ccb59687dba3bfb273d54b08a261b2f3002': compute_scrypt_nonce,
     'h7b0c470f0cfe3a80a9e26526ad185f484f6817d0832712a4a37a908786a6a67f': hash_pow,
     'ha9faaffd31b4d5ede2a2e19d2d7fd525f66fee61911511960dcbb52d3c48ce25': "mp_verify"


### PR DESCRIPTION
```python
Challenge Input: eyJ2ZXJzaW9uIjoxLCJ1YmlkIjoiMDk4Y2ZmNDQtMmRjOC00OT...
Checksum: B3CBDF0A
Difficulty: 4
Memory Cost: 128
Challenge Type: HashcashScrypt
==========================================================================================

1. Testing Current Production (pyscrypt)
----------------------------------------------------------------------
Description: What you currently use
Result: 38
Time: 5.9083 seconds
Verification: ✓ VALID

2. Testing Optimized pyscrypt
----------------------------------------------------------------------
Description: pyscrypt with optimizations
Result: 38
Time: 5.9010 seconds
Verification: ✓ VALID

3. Testing hashlib.scrypt (basic)
----------------------------------------------------------------------
Description: Built-in Python scrypt
Result: 38
Time: 0.0161 seconds
Verification: ✓ VALID

4. Testing hashlib.scrypt (optimized)
----------------------------------------------------------------------
Description: hashlib with optimizations
Result: 38
Time: 0.0163 seconds
Verification: ✓ VALID

==========================================================================================
SCRYPT PERFORMANCE COMPARISON
==========================================================================================
Implementation                 Time (s)     Result     Valid    Library
---------------------------------------------------------------------------
Current Production (pyscrypt)  5.9083       38         ✓        pyscrypt
Optimized pyscrypt             5.9010       38         ✓        pyscrypt
hashlib.scrypt (basic)         0.0161       38         ✓        hashlib
hashlib.scrypt (optimized)     0.0163       38         ✓        hashlib

==========================================================================================
KEY FINDINGS
==========================================================================================
🏆 FASTEST: hashlib.scrypt (basic)
   Time: 0.0161 seconds
   Result: 38
   Library: hashlib
   Speedup vs current: 366.1x faster
   Time saved: 5.8922 seconds per solve

--- COMPATIBILITY CHECK ---
✅ COMPATIBLE: Both libraries find the same nonce
   Both found: 38
   ✅ Safe to switch libraries

--- LIBRARY PERFORMANCE ---
📈 hashlib.scrypt is 366x FASTER
   pyscrypt: 5.9083s
   hashlib:  0.0161s

--- OPTIMIZATION EFFECTIVENESS ---
pyscrypt optimization: 1.00x speedup
hashlib optimization: 0.99x speedup
```